### PR TITLE
feat(score): スコア・レベルシステムを実装

### DIFF
--- a/.zen/memory/checkpoint.json
+++ b/.zen/memory/checkpoint.json
@@ -3,10 +3,11 @@
   "command": "zen:issue:start",
   "issue_number": 7,
   "branch": "feat/issue-7-score-level-system",
-  "phase": "phase4",
-  "timestamp": "2026-01-15T12:20:00+09:00",
+  "phase": "phase5_review",
+  "timestamp": "2026-01-15T12:45:00+09:00",
   "context": {
     "issue_title": "スコア・レベルシステム",
-    "ready_for_implementation": true
+    "pr_number": 19,
+    "review_result": "mergeable"
   }
 }

--- a/src/systems/ScoreManager.test.ts
+++ b/src/systems/ScoreManager.test.ts
@@ -32,6 +32,11 @@ describe('ScoreManager', () => {
       const manager = new ScoreManager(0);
       expect(manager.level).toBe(1);
     });
+
+    it('should enforce minimum level of 1 for negative values', () => {
+      const manager = new ScoreManager(-5);
+      expect(manager.level).toBe(1);
+    });
   });
 
   describe('line clear scoring', () => {
@@ -154,6 +159,16 @@ describe('ScoreManager', () => {
       };
       const points = scoreManager.processLineClear(result);
       expect(points).toBe(1600);
+    });
+
+    it('should score T-Spin Mini Double at 400 × level', () => {
+      const result: LineClearResult = {
+        linesCleared: 2,
+        tspinType: 'mini',
+        description: 'T-Spin Mini Double',
+      };
+      const points = scoreManager.processLineClear(result);
+      expect(points).toBe(400);
     });
   });
 
@@ -287,6 +302,19 @@ describe('ScoreManager', () => {
       expect(scoreManager.combo).toBe(0);
 
       scoreManager.processLineClear(noLines);
+      expect(scoreManager.combo).toBe(-1);
+    });
+
+    it('should reset combo via resetCombo method', () => {
+      const single: LineClearResult = {
+        linesCleared: 1,
+        tspinType: 'none',
+        description: 'Single',
+      };
+      scoreManager.processLineClear(single);
+      expect(scoreManager.combo).toBe(0);
+
+      scoreManager.resetCombo();
       expect(scoreManager.combo).toBe(-1);
     });
   });

--- a/src/systems/ScoreManager.ts
+++ b/src/systems/ScoreManager.ts
@@ -294,17 +294,6 @@ export class ScoreManager {
   }
 
   /**
-   * Called when a piece locks without clearing lines.
-   * Resets the combo counter.
-   */
-  onPieceLock(): void {
-    // Combo is reset when a piece locks without clearing lines
-    // This method should be called by the game when a piece locks
-    // The actual reset happens in processLineClear when linesCleared is 0
-    // and there's no T-Spin
-  }
-
-  /**
    * Reset combo counter (called when piece locks without line clear).
    */
   resetCombo(): void {
@@ -323,18 +312,18 @@ export class ScoreManager {
 
   /**
    * Add soft drop bonus points.
-   * @param cells - Number of cells dropped
+   * @param cells - Number of cells dropped (must be non-negative)
    */
   addSoftDropBonus(cells: number): void {
-    this._score += cells * SOFT_DROP_BONUS;
+    this._score += Math.max(0, cells) * SOFT_DROP_BONUS;
   }
 
   /**
    * Add hard drop bonus points.
-   * @param cells - Number of cells dropped
+   * @param cells - Number of cells dropped (must be non-negative)
    */
   addHardDropBonus(cells: number): void {
-    this._score += cells * HARD_DROP_BONUS;
+    this._score += Math.max(0, cells) * HARD_DROP_BONUS;
   }
 
   /**


### PR DESCRIPTION
## 概要

Tetris Guideline に準拠したスコア計算とレベルシステムを実装しました。

## 関連 Issue

Closes #7

## 変更内容

### 新規ファイル
- `src/systems/ScoreManager.ts` - スコア・レベル管理クラス
- `src/systems/ScoreManager.test.ts` - テストスイート（34テスト）

### 実装した機能

#### スコアリング
| アクション | 点数 |
|-----------|------|
| Single | 100 × level |
| Double | 300 × level |
| Triple | 500 × level |
| Tetris | 800 × level |
| T-Spin Mini | 100 × level |
| T-Spin | 400 × level |
| T-Spin Single | 800 × level |
| T-Spin Double | 1200 × level |
| T-Spin Triple | 1600 × level |

#### ボーナス
- **Back-to-Back**: 連続 Tetris/T-Spin で 1.5 倍
- **コンボ**: 50 × combo × level
- **Soft Drop**: 1 point/cell
- **Hard Drop**: 2 points/cell

#### レベルシステム
- 10 ライン消去でレベルアップ
- レベルに応じた落下速度テーブル（指数関数的上昇）

## テスト結果

全 34 テストがパス:
- 基本スコアリング
- T-Spin スコアリング
- Back-to-Back ボーナス
- コンボシステム
- レベル進行
- 落下速度
- ドロップボーナス

## チェックリスト

- [x] 実装完了
- [x] テスト追加（34テスト）
- [x] lint パス

🤖 Generated with [Claude Code](https://claude.ai/code)